### PR TITLE
Chore: Disable Move Selection while animating

### DIFF
--- a/components/OpponentMoveDisplay.tsx
+++ b/components/OpponentMoveDisplay.tsx
@@ -1,14 +1,16 @@
 const OpponentMoveDisplay = ({
   opponent,
   opponentMove,
+  isAnimating,
 }: {
   opponent: string;
   opponentMove: number;
+  isAnimating: boolean;
 }) => (
   <p className="text-xl mt-4">
     {opponent} chose:{" "}
     <span className="text-red-400">
-      {opponentMove !== null ? opponentMove : "-"}
+      {!isAnimating && opponentMove !== null ? opponentMove : "-"}
     </span>
   </p>
 );

--- a/src/app/game/page.tsx
+++ b/src/app/game/page.tsx
@@ -224,7 +224,7 @@ const Game = () => {
     }
     setTimeout(() => {
       setIsAnimating(false);
-    }, 1500);
+    }, 1200);
   };
 
   const declareWinner = (userScore: number, opponentScore: number) => {
@@ -475,6 +475,7 @@ const Game = () => {
             <OpponentMoveDisplay
               opponent={opponent || "Opponent"}
               opponentMove={opponentMove === null ? 0 : opponentMove}
+              isAnimating={isAnimating}
             />
           </>
         )}

--- a/src/app/game/page.tsx
+++ b/src/app/game/page.tsx
@@ -39,6 +39,7 @@ const Game = () => {
   const [playerMovesHistory, setPlayerMovesHistory] = useState<number[]>([]);
   const [botMovesHistory, setBotMovesHistory] = useState<number[]>([]);
   const [gameResults, setGameResults] = useState<string[]>([]);
+  const [isAnimating, setIsAnimating] = useState(false);
 
   const updateGameResults = useCallback((result: string) => {
     setGameResults((prevResults: string[]) => [...prevResults, result]);
@@ -203,8 +204,9 @@ const Game = () => {
   };
 
   const playMove = (move: number) => {
-    if (isGameOver) return;
+    if (isGameOver || isAnimating || !gameStarted || showInningsOverlay || showPopup || showGameStartPopup) return;
 
+    setIsAnimating(true);
     setPlayerMove(move);
     setPlayerMovesHistory((prevHistory) => [...prevHistory, move]);
 
@@ -220,6 +222,9 @@ const Game = () => {
     } else {
       socketService.sendMove(move);
     }
+    setTimeout(() => {
+      setIsAnimating(false);
+    }, 1500);
   };
 
   const declareWinner = (userScore: number, opponentScore: number) => {
@@ -465,7 +470,7 @@ const Game = () => {
             <MoveSelection
               playerMove={playerMove === null ? 0 : playerMove}
               playMove={playMove}
-              isDisabled={isGameOver}
+              isDisabled={isGameOver || isAnimating || !gameStarted || showInningsOverlay || showPopup || showGameStartPopup}
             />
             <OpponentMoveDisplay
               opponent={opponent || "Opponent"}


### PR DESCRIPTION
This adds a watch to check animation state, a timeout is added of the same duration as animation to disable move selection. Move selection will be disabled during Game Over & Animation & while game not started & while innings are switching & in case of any pop ups.